### PR TITLE
Added support for custom AIDs

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -6,13 +6,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"fyne.io/fyne/v2/dialog"
-	"github.com/mattn/go-runewidth"
 	"io"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"fyne.io/fyne/v2/dialog"
+	"github.com/mattn/go-runewidth"
 )
 
 func runLpac(args ...string) (json.RawMessage, error) {
@@ -42,6 +43,7 @@ func runLpac(args ...string) (json.RawMessage, error) {
 		fmt.Sprintf("LPAC_APDU=pcsc"),
 		fmt.Sprintf("LPAC_HTTP=curl"),
 		fmt.Sprintf("DRIVER_IFID=%s", ConfigInstance.DriverIFID),
+		fmt.Sprintf("LPAC_CUSTOM_ISD_R_AID=%s", ConfigInstance.LpacAID),
 	}
 	if ConfigInstance.DebugHTTP {
 		cmd.Env = append(cmd.Env, "LIBEUICC_DEBUG_HTTP=1")

--- a/config.go
+++ b/config.go
@@ -10,6 +10,7 @@ import (
 
 type Config struct {
 	LpacDir     string
+	LpacAID     string
 	EXEName     string
 	DriverIFID  string
 	DebugHTTP   bool
@@ -44,6 +45,7 @@ func LoadConfig() error {
 		ConfigInstance.LogDir = filepath.Join("/tmp", "EasyLPAC-log")
 	}
 	ConfigInstance.AutoMode = true
+	ConfigInstance.LpacAID = "A0000005591010FFFFFFFF8900000100"
 
 	ConfigInstance.LogFilename = fmt.Sprintf("lpac-%s.txt", time.Now().Format("20060102-150405"))
 	return nil


### PR DESCRIPTION
This allows the usage of custom AIDs.
Please note, that I'm not a GUI designer and never used GO or fyne.

We could instead try other known AIDs, if the default `A0000005591010FFFFFFFF8900000100` fails.
This would make the process easier. I don't know if this project would be fine with such an approach.

This depends on https://github.com/estkme-group/lpac/pull/181
This closes #26