### PR TITLE
feat: add MBIM backend support and dynamic driver discovery for eSIM management

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -40,10 +40,14 @@ func runLpac(args ...string) (json.RawMessage, error) {
 	cmd.Dir = ConfigInstance.LpacDir
 
 	cmd.Env = []string{
-		"LPAC_APDU=pcsc",
+		fmt.Sprintf("LPAC_APDU=%s", ConfigInstance.ApduBackend),
 		"LPAC_HTTP=curl",
-		fmt.Sprintf("DRIVER_IFID=%s", ConfigInstance.DriverIFID),
 		fmt.Sprintf("LPAC_CUSTOM_ISD_R_AID=%s", ConfigInstance.LpacAID),
+	}
+	if ConfigInstance.ApduBackend == "pcsc" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("DRIVER_IFID=%s", ConfigInstance.DriverIFID))
+	} else if ConfigInstance.ApduBackend == "mbim" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("LPAC_APDU_MBIM_DEVICE=%s", ConfigInstance.MbimDevice))
 	}
 	if ConfigInstance.DebugHTTP {
 		cmd.Env = append(cmd.Env, "LIBEUICC_DEBUG_HTTP=1")

--- a/cmd.go
+++ b/cmd.go
@@ -16,6 +16,46 @@ import (
 	"github.com/mattn/go-runewidth"
 )
 
+// runLpacRaw runs lpac with custom environment, used for driver discovery
+func runLpacRaw(env []string, args ...string) (json.RawMessage, string, error) {
+	lpacPath := filepath.Join(ConfigInstance.LpacDir, ConfigInstance.EXEName)
+
+	cmd := exec.Command(lpacPath, args...)
+	HideCmdWindow(cmd)
+	cmd.Dir = ConfigInstance.LpacDir
+	cmd.Env = env
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil && len(bytes.TrimSpace(stderr.Bytes())) != 0 {
+		return nil, "", errors.New(stderr.String())
+	}
+
+	// Parse the response - look for "driver" type for driver commands
+	scanner := bufio.NewScanner(&stdout)
+	for scanner.Scan() {
+		var resp struct {
+			Type    string `json:"type"`
+			Payload struct {
+				Env  string          `json:"env"`
+				Data json.RawMessage `json:"data"`
+			} `json:"payload"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &resp); err != nil {
+			continue
+		}
+		if resp.Type == "driver" {
+			return resp.Payload.Data, resp.Payload.Env, nil
+		}
+	}
+
+	return nil, "", errors.New("no driver response found")
+}
+
 func runLpac(args ...string) (json.RawMessage, error) {
 	StatusChan <- StatusProcess
 	LockButtonChan <- true
@@ -39,16 +79,8 @@ func runLpac(args ...string) (json.RawMessage, error) {
 
 	cmd.Dir = ConfigInstance.LpacDir
 
-	cmd.Env = []string{
-		fmt.Sprintf("LPAC_APDU=%s", ConfigInstance.ApduBackend),
-		"LPAC_HTTP=curl",
-		fmt.Sprintf("LPAC_CUSTOM_ISD_R_AID=%s", ConfigInstance.LpacAID),
-	}
-	if ConfigInstance.ApduBackend == "pcsc" {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("DRIVER_IFID=%s", ConfigInstance.DriverIFID))
-	} else if ConfigInstance.ApduBackend == "mbim" {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("LPAC_APDU_MBIM_DEVICE=%s", ConfigInstance.MbimDevice))
-	}
+	cmd.Env = buildDriverEnv()
+
 	if ConfigInstance.DebugHTTP {
 		cmd.Env = append(cmd.Env, "LIBEUICC_DEBUG_HTTP=1")
 	}
@@ -131,6 +163,108 @@ func runLpac(args ...string) (json.RawMessage, error) {
 		return nil, err
 	}
 	return resp.Payload.Data, nil
+}
+
+// buildDriverEnv builds environment variables for the current driver
+func buildDriverEnv() []string {
+	env := []string{
+		fmt.Sprintf("LPAC_APDU=%s", ConfigInstance.ApduBackend),
+		"LPAC_HTTP=curl",
+		fmt.Sprintf("LPAC_CUSTOM_ISD_R_AID=%s", ConfigInstance.LpacAID),
+	}
+
+	config := GetCurrentDriverConfig()
+	if config == nil {
+		return env
+	}
+
+	driver := ConfigInstance.ApduBackend
+
+	// Add driver-specific environment variables
+	switch driver {
+	case "pcsc":
+		if config.DriverIFID != "" {
+			env = append(env, fmt.Sprintf("LPAC_APDU_PCSC_DRV_IFID=%s", config.DriverIFID))
+		}
+	case "at":
+		if config.DriverIFID != "" {
+			env = append(env, fmt.Sprintf("LPAC_APDU_PCSC_DRV_IFID=%s", config.DriverIFID))
+		}
+		if config.DevicePath != "" {
+			env = append(env, fmt.Sprintf("LPAC_APDU_AT_DEVICE=%s", config.DevicePath))
+		}
+	case "at_csim":
+		if config.DevicePath != "" {
+			env = append(env, fmt.Sprintf("LPAC_APDU_AT_DEVICE=%s", config.DevicePath))
+		}
+	case "mbim":
+		if config.DevicePath != "" {
+			env = append(env, fmt.Sprintf("LPAC_APDU_MBIM_DEVICE=%s", config.DevicePath))
+		}
+		if config.UimSlot > 0 {
+			env = append(env, fmt.Sprintf("LPAC_APDU_MBIM_UIM_SLOT=%d", config.UimSlot))
+		}
+	case "qmi", "qmi_qrtr", "uqmi":
+		if config.DevicePath != "" {
+			env = append(env, fmt.Sprintf("LPAC_APDU_QMI_DEVICE=%s", config.DevicePath))
+		}
+		if config.UimSlot > 0 {
+			env = append(env, fmt.Sprintf("LPAC_APDU_QMI_UIM_SLOT=%d", config.UimSlot))
+		}
+	}
+	// gbinder and gbinder_hidl need no additional env vars
+
+	return env
+}
+
+// LpacDriverList queries available APDU drivers
+func LpacDriverList() ([]string, error) {
+	env := []string{
+		"LPAC_HTTP=curl",
+	}
+
+	data, _, err := runLpacRaw(env, "driver", "list")
+	if err != nil {
+		return nil, err
+	}
+
+	var drivers []string
+	if err = json.Unmarshal(data, &drivers); err != nil {
+		return nil, err
+	}
+	return drivers, nil
+}
+
+// LpacDriverApduList lists available devices for the current APDU driver
+func LpacDriverApduList() ([]*ApduDriver, error) {
+	payload, err := runLpac("driver", "apdu", "list")
+	if err != nil {
+		return nil, err
+	}
+	var apduDrivers []*ApduDriver
+	if err = json.Unmarshal(payload, &apduDrivers); err != nil {
+		return nil, err
+	}
+	return apduDrivers, nil
+}
+
+// LpacDriverApduListForDriver lists available devices for a specific APDU driver
+func LpacDriverApduListForDriver(driver string) ([]*ApduDriver, error) {
+	env := []string{
+		fmt.Sprintf("LPAC_APDU=%s", driver),
+		"LPAC_HTTP=curl",
+	}
+
+	data, _, err := runLpacRaw(env, "driver", "apdu", "list")
+	if err != nil {
+		return nil, err
+	}
+
+	var apduDrivers []*ApduDriver
+	if err = json.Unmarshal(data, &apduDrivers); err != nil {
+		return nil, err
+	}
+	return apduDrivers, nil
 }
 
 func LpacChipInfo() (*EuiccInfo, error) {
@@ -268,18 +402,6 @@ func LpacNotificationRemove(seq int) error {
 		return err
 	}
 	return nil
-}
-
-func LpacDriverApduList() ([]*ApduDriver, error) {
-	payload, err := runLpac("driver", "apdu", "list")
-	if err != nil {
-		return nil, err
-	}
-	var apduDrivers []*ApduDriver
-	if err = json.Unmarshal(payload, &apduDrivers); err != nil {
-		return nil, err
-	}
-	return apduDrivers, nil
 }
 
 func LpacChipDefaultSmdp(smdp string) error {

--- a/cmd.go
+++ b/cmd.go
@@ -39,17 +39,14 @@ func runLpacRaw(env []string, args ...string) (json.RawMessage, string, error) {
 	scanner := bufio.NewScanner(&stdout)
 	for scanner.Scan() {
 		var resp struct {
-			Type    string `json:"type"`
-			Payload struct {
-				Env  string          `json:"env"`
-				Data json.RawMessage `json:"data"`
-			} `json:"payload"`
+			Type    string          `json:"type"`
+			Payload json.RawMessage `json:"payload"`
 		}
 		if err := json.Unmarshal(scanner.Bytes(), &resp); err != nil {
 			continue
 		}
 		if resp.Type == "driver" {
-			return resp.Payload.Data, resp.Payload.Env, nil
+			return resp.Payload, "", nil
 		}
 	}
 
@@ -156,10 +153,26 @@ func runLpac(args ...string) (json.RawMessage, error) {
 				}
 				return wrappedText.String()
 			}
-			return nil, fmt.Errorf("Function: %s\nData: %s", resp.Payload.Message, wrapText(dataString, 90))
+			// Build error message with stderr first if available
+			stderrStr := strings.TrimSpace(stderr.String())
+			var errMsg string
+			if stderrStr != "" {
+				errMsg = fmt.Sprintf("%s\n\nFunction: %s\nData: %s", stderrStr, resp.Payload.Message, wrapText(dataString, 90))
+			} else {
+				errMsg = fmt.Sprintf("Function: %s\nData: %s", resp.Payload.Message, wrapText(dataString, 90))
+			}
+			return nil, errors.New(errMsg)
 		}
 	}
 	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	// Check if command failed with stderr but no JSON error response
+	if err != nil {
+		stderrStr := strings.TrimSpace(stderr.String())
+		if stderrStr != "" {
+			return nil, errors.New(stderrStr)
+		}
 		return nil, err
 	}
 	return resp.Payload.Data, nil
@@ -190,24 +203,32 @@ func buildDriverEnv() []string {
 		if config.DriverIFID != "" {
 			env = append(env, fmt.Sprintf("LPAC_APDU_PCSC_DRV_IFID=%s", config.DriverIFID))
 		}
-		if config.DevicePath != "" {
-			env = append(env, fmt.Sprintf("LPAC_APDU_AT_DEVICE=%s", config.DevicePath))
+		devicePath := config.DevicePath
+		if devicePath == "" {
+			devicePath = GetDefaultDevicePath("at")
 		}
+		env = append(env, fmt.Sprintf("LPAC_APDU_AT_DEVICE=%s", devicePath))
 	case "at_csim":
-		if config.DevicePath != "" {
-			env = append(env, fmt.Sprintf("LPAC_APDU_AT_DEVICE=%s", config.DevicePath))
+		devicePath := config.DevicePath
+		if devicePath == "" {
+			devicePath = GetDefaultDevicePath("at_csim")
 		}
+		env = append(env, fmt.Sprintf("LPAC_APDU_AT_DEVICE=%s", devicePath))
 	case "mbim":
-		if config.DevicePath != "" {
-			env = append(env, fmt.Sprintf("LPAC_APDU_MBIM_DEVICE=%s", config.DevicePath))
+		devicePath := config.DevicePath
+		if devicePath == "" {
+			devicePath = GetDefaultDevicePath("mbim")
 		}
+		env = append(env, fmt.Sprintf("LPAC_APDU_MBIM_DEVICE=%s", devicePath))
 		if config.UimSlot > 0 {
 			env = append(env, fmt.Sprintf("LPAC_APDU_MBIM_UIM_SLOT=%d", config.UimSlot))
 		}
 	case "qmi", "qmi_qrtr", "uqmi":
-		if config.DevicePath != "" {
-			env = append(env, fmt.Sprintf("LPAC_APDU_QMI_DEVICE=%s", config.DevicePath))
+		devicePath := config.DevicePath
+		if devicePath == "" {
+			devicePath = GetDefaultDevicePath(driver)
 		}
+		env = append(env, fmt.Sprintf("LPAC_APDU_QMI_DEVICE=%s", devicePath))
 		if config.UimSlot > 0 {
 			env = append(env, fmt.Sprintf("LPAC_APDU_QMI_UIM_SLOT=%d", config.UimSlot))
 		}
@@ -228,11 +249,14 @@ func LpacDriverList() ([]string, error) {
 		return nil, err
 	}
 
-	var drivers []string
-	if err = json.Unmarshal(data, &drivers); err != nil {
+	var payload struct {
+		LpacApdu []string `json:"LPAC_APDU"`
+		LpacHttp []string `json:"LPAC_HTTP"`
+	}
+	if err = json.Unmarshal(data, &payload); err != nil {
 		return nil, err
 	}
-	return drivers, nil
+	return payload.LpacApdu, nil
 }
 
 // LpacDriverApduList lists available devices for the current APDU driver
@@ -260,11 +284,14 @@ func LpacDriverApduListForDriver(driver string) ([]*ApduDriver, error) {
 		return nil, err
 	}
 
-	var apduDrivers []*ApduDriver
-	if err = json.Unmarshal(data, &apduDrivers); err != nil {
+	var payload struct {
+		Env  string        `json:"env"`
+		Data []*ApduDriver `json:"data"`
+	}
+	if err = json.Unmarshal(data, &payload); err != nil {
 		return nil, err
 	}
-	return apduDrivers, nil
+	return payload.Data, nil
 }
 
 func LpacChipInfo() (*EuiccInfo, error) {

--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"time"
@@ -24,6 +25,8 @@ type Config struct {
 	LogFilename string
 	LogFile     *os.File
 	AutoMode    bool
+	ApduBackend string // "pcsc" or "mbim"
+	MbimDevice  string // MBIM device path, e.g., "/dev/wwan0mbim0"
 }
 
 var ConfigInstance Config
@@ -49,7 +52,12 @@ func LoadConfig() error {
 		ConfigInstance.LogDir = filepath.Join("/tmp", "EasyLPAC-log")
 		_, err = os.Stat(filepath.Join(ConfigInstance.LpacDir, ConfigInstance.EXEName))
 		if err != nil {
-			ConfigInstance.LpacDir = "/usr/bin"
+			// Try to find lpac in PATH
+			if lpacPath, pathErr := exec.LookPath("lpac"); pathErr == nil {
+				ConfigInstance.LpacDir = filepath.Dir(lpacPath)
+			} else {
+				ConfigInstance.LpacDir = "/usr/bin"
+			}
 		}
 	default:
 		ConfigInstance.EXEName = "lpac"
@@ -57,6 +65,12 @@ func LoadConfig() error {
 	}
 	ConfigInstance.AutoMode = true
 	ConfigInstance.LpacAID = AID_DEFAULT
+	ConfigInstance.ApduBackend = "pcsc"
+	if mbimDevice := os.Getenv("LPAC_APDU_MBIM_DEVICE"); mbimDevice != "" {
+		ConfigInstance.MbimDevice = mbimDevice
+	} else {
+		ConfigInstance.MbimDevice = "/dev/cdc-wdm0"
+	}
 
 	ConfigInstance.LogFilename = fmt.Sprintf("lpac-%s.txt", time.Now().Format("20060102-150405"))
 	return nil

--- a/config.go
+++ b/config.go
@@ -163,13 +163,14 @@ func LoadConfig() error {
 	ConfigInstance.DriverConfigs = make(map[string]DriverConfig)
 
 	// Initialize configs for all known drivers
+	// Only use env variables, not defaults - defaults are shown as placeholders
 	initDriverConfig("pcsc", os.Getenv("LPAC_APDU_PCSC_DRV_IFID"), 0)
-	initDriverConfig("at", getEnvOrDefault("LPAC_APDU_AT_DEVICE", GetDefaultDevicePath("at")), 0)
-	initDriverConfig("at_csim", getEnvOrDefault("LPAC_APDU_AT_DEVICE", GetDefaultDevicePath("at_csim")), 0)
-	initDriverConfig("mbim", getEnvOrDefault("LPAC_APDU_MBIM_DEVICE", GetDefaultDevicePath("mbim")), getEnvIntOrDefault("LPAC_APDU_MBIM_UIM_SLOT", 1))
-	initDriverConfig("qmi", getEnvOrDefault("LPAC_APDU_QMI_DEVICE", GetDefaultDevicePath("qmi")), getEnvIntOrDefault("LPAC_APDU_QMI_UIM_SLOT", 1))
-	initDriverConfig("qmi_qrtr", getEnvOrDefault("LPAC_APDU_QMI_DEVICE", GetDefaultDevicePath("qmi_qrtr")), getEnvIntOrDefault("LPAC_APDU_QMI_UIM_SLOT", 1))
-	initDriverConfig("uqmi", getEnvOrDefault("LPAC_APDU_QMI_DEVICE", GetDefaultDevicePath("uqmi")), getEnvIntOrDefault("LPAC_APDU_QMI_UIM_SLOT", 1))
+	initDriverConfig("at", os.Getenv("LPAC_APDU_AT_DEVICE"), 0)
+	initDriverConfig("at_csim", os.Getenv("LPAC_APDU_AT_DEVICE"), 0)
+	initDriverConfig("mbim", os.Getenv("LPAC_APDU_MBIM_DEVICE"), getEnvIntOrDefault("LPAC_APDU_MBIM_UIM_SLOT", 1))
+	initDriverConfig("qmi", os.Getenv("LPAC_APDU_QMI_DEVICE"), getEnvIntOrDefault("LPAC_APDU_QMI_UIM_SLOT", 1))
+	initDriverConfig("qmi_qrtr", os.Getenv("LPAC_APDU_QMI_DEVICE"), getEnvIntOrDefault("LPAC_APDU_QMI_UIM_SLOT", 1))
+	initDriverConfig("uqmi", os.Getenv("LPAC_APDU_QMI_DEVICE"), getEnvIntOrDefault("LPAC_APDU_QMI_UIM_SLOT", 1))
 	initDriverConfig("gbinder", "", 0)
 	initDriverConfig("gbinder_hidl", "", 0)
 

--- a/config.go
+++ b/config.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"time"
 )
 
@@ -14,22 +15,113 @@ const AID_5BER = "A0000005591010FFFFFFFF8900050500"
 const AID_ESIMME = "A0000005591010000000008900000300"
 const AID_XESIM = "A0000005591010FFFFFFFF8900000177"
 
+// DriverConfig holds configuration for a specific APDU backend driver
+type DriverConfig struct {
+	DevicePath string // Device path (for at, mbim, qmi drivers)
+	UimSlot    int    // UIM slot number (for mbim, qmi drivers)
+	DriverIFID string // Driver interface ID (for pcsc, at drivers with enumeration)
+}
+
 type Config struct {
 	LpacDir     string
 	LpacAID     string
 	EXEName     string
-	DriverIFID  string
 	DebugHTTP   bool
 	DebugAPDU   bool
 	LogDir      string
 	LogFilename string
 	LogFile     *os.File
 	AutoMode    bool
-	ApduBackend string // "pcsc" or "mbim"
-	MbimDevice  string // MBIM device path, e.g., "/dev/wwan0mbim0"
+
+	// APDU backend configuration
+	ApduBackend   string                  // Current backend: pcsc, mbim, at, qmi, etc.
+	DriverConfigs map[string]DriverConfig // Config per driver type
 }
 
 var ConfigInstance Config
+
+// AvailableDrivers holds the list of drivers returned by lpac
+var AvailableDrivers []string
+
+// DriversWithEnumeration are drivers that support device listing via combobox
+var DriversWithEnumeration = map[string]bool{
+	"pcsc": true,
+	"at":   true,
+}
+
+// DriversWithDevicePath are drivers that need a device path
+var DriversWithDevicePath = map[string]bool{
+	"at":       true,
+	"at_csim":  true,
+	"mbim":     true,
+	"qmi":      true,
+	"qmi_qrtr": true,
+	"uqmi":     true,
+}
+
+// DriversWithUimSlot are drivers that need a UIM slot number
+var DriversWithUimSlot = map[string]bool{
+	"mbim":     true,
+	"qmi":      true,
+	"qmi_qrtr": true,
+	"uqmi":     true,
+}
+
+// DriversNoConfig are drivers that need no configuration
+var DriversNoConfig = map[string]bool{
+	"gbinder":      true,
+	"gbinder_hidl": true,
+}
+
+// IsKnownDriver returns true if the driver is recognized
+func IsKnownDriver(driver string) bool {
+	return DriversWithEnumeration[driver] ||
+		DriversWithDevicePath[driver] ||
+		DriversNoConfig[driver]
+}
+
+// GetDriverEnvVarName returns the environment variable name for a driver's device path
+func GetDriverEnvVarName(driver string) string {
+	switch driver {
+	case "at", "at_csim":
+		return "LPAC_APDU_AT_DEVICE"
+	case "mbim":
+		return "LPAC_APDU_MBIM_DEVICE"
+	case "qmi", "qmi_qrtr", "uqmi":
+		return "LPAC_APDU_QMI_DEVICE"
+	case "pcsc":
+		return "LPAC_APDU_PCSC_DRV_IFID"
+	default:
+		return ""
+	}
+}
+
+// GetDriverSlotEnvVarName returns the environment variable name for a driver's UIM slot
+func GetDriverSlotEnvVarName(driver string) string {
+	switch driver {
+	case "mbim":
+		return "LPAC_APDU_MBIM_UIM_SLOT"
+	case "qmi", "qmi_qrtr", "uqmi":
+		return "LPAC_APDU_QMI_UIM_SLOT"
+	default:
+		return ""
+	}
+}
+
+// GetDefaultDevicePath returns the default device path for a driver
+func GetDefaultDevicePath(driver string) string {
+	switch driver {
+	case "at", "at_csim":
+		if runtime.GOOS == "windows" {
+			return "COM3"
+		}
+		return "/dev/ttyUSB0"
+	case "mbim", "qmi", "qmi_qrtr", "uqmi":
+		return "/dev/cdc-wdm0"
+	default:
+		return ""
+	}
+}
 
 func LoadConfig() error {
 	exePath, err := os.Executable()
@@ -65,13 +157,59 @@ func LoadConfig() error {
 	}
 	ConfigInstance.AutoMode = true
 	ConfigInstance.LpacAID = AID_DEFAULT
-	ConfigInstance.ApduBackend = "pcsc"
-	if mbimDevice := os.Getenv("LPAC_APDU_MBIM_DEVICE"); mbimDevice != "" {
-		ConfigInstance.MbimDevice = mbimDevice
-	} else {
-		ConfigInstance.MbimDevice = "/dev/cdc-wdm0"
-	}
+	ConfigInstance.ApduBackend = "" // Will be set after driver discovery
+
+	// Initialize driver configs with defaults from environment variables
+	ConfigInstance.DriverConfigs = make(map[string]DriverConfig)
+
+	// Initialize configs for all known drivers
+	initDriverConfig("pcsc", os.Getenv("LPAC_APDU_PCSC_DRV_IFID"), 0)
+	initDriverConfig("at", getEnvOrDefault("LPAC_APDU_AT_DEVICE", GetDefaultDevicePath("at")), 0)
+	initDriverConfig("at_csim", getEnvOrDefault("LPAC_APDU_AT_DEVICE", GetDefaultDevicePath("at_csim")), 0)
+	initDriverConfig("mbim", getEnvOrDefault("LPAC_APDU_MBIM_DEVICE", GetDefaultDevicePath("mbim")), getEnvIntOrDefault("LPAC_APDU_MBIM_UIM_SLOT", 1))
+	initDriverConfig("qmi", getEnvOrDefault("LPAC_APDU_QMI_DEVICE", GetDefaultDevicePath("qmi")), getEnvIntOrDefault("LPAC_APDU_QMI_UIM_SLOT", 1))
+	initDriverConfig("qmi_qrtr", getEnvOrDefault("LPAC_APDU_QMI_DEVICE", GetDefaultDevicePath("qmi_qrtr")), getEnvIntOrDefault("LPAC_APDU_QMI_UIM_SLOT", 1))
+	initDriverConfig("uqmi", getEnvOrDefault("LPAC_APDU_QMI_DEVICE", GetDefaultDevicePath("uqmi")), getEnvIntOrDefault("LPAC_APDU_QMI_UIM_SLOT", 1))
+	initDriverConfig("gbinder", "", 0)
+	initDriverConfig("gbinder_hidl", "", 0)
 
 	ConfigInstance.LogFilename = fmt.Sprintf("lpac-%s.txt", time.Now().Format("20060102-150405"))
 	return nil
+}
+
+func initDriverConfig(driver, devicePath string, uimSlot int) {
+	ConfigInstance.DriverConfigs[driver] = DriverConfig{
+		DevicePath: devicePath,
+		UimSlot:    uimSlot,
+		DriverIFID: "",
+	}
+}
+
+func getEnvOrDefault(envVar, defaultVal string) string {
+	if val := os.Getenv(envVar); val != "" {
+		return val
+	}
+	return defaultVal
+}
+
+func getEnvIntOrDefault(envVar string, defaultVal int) int {
+	if val := os.Getenv(envVar); val != "" {
+		if intVal, err := strconv.Atoi(val); err == nil {
+			return intVal
+		}
+	}
+	return defaultVal
+}
+
+// GetCurrentDriverConfig returns the config for the currently selected driver
+func GetCurrentDriverConfig() *DriverConfig {
+	if config, ok := ConfigInstance.DriverConfigs[ConfigInstance.ApduBackend]; ok {
+		return &config
+	}
+	return nil
+}
+
+// SetCurrentDriverConfig updates the config for the currently selected driver
+func SetCurrentDriverConfig(config DriverConfig) {
+	ConfigInstance.DriverConfigs[ConfigInstance.ApduBackend] = config
 }

--- a/control.go
+++ b/control.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"runtime"
 	"sort"
-	"strings"
 
 	fyne "fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/dialog"
@@ -36,7 +35,6 @@ func RefreshProfile() error {
 	if err != nil {
 		return err
 	}
-	// 刷新 List
 	fyne.Do(func() {
 		ProfileList.Refresh()
 		ProfileList.UnselectAll()
@@ -55,7 +53,6 @@ func RefreshNotification() error {
 	sort.Slice(Notifications, func(i, j int) bool {
 		return Notifications[i].SeqNumber < Notifications[j].SeqNumber
 	})
-	// 刷新 List
 	fyne.Do(func() {
 		NotificationList.Refresh()
 		NotificationList.UnselectAll()
@@ -87,20 +84,17 @@ func RefreshChipInfo() error {
 		EidLabel.SetText(fmt.Sprintf(TR.Trans("label.info_eid")+" %s", ChipInfo.EidValue))
 		DefaultDpAddressLabel.SetText(fmt.Sprintf(TR.Trans("label.default_smdp_address")+"  %s", convertToString(ChipInfo.EuiccConfiguredAddresses.DefaultDpAddress)))
 		RootDsAddressLabel.SetText(fmt.Sprintf(TR.Trans("label.root_smds_address")+"  %s", convertToString(ChipInfo.EuiccConfiguredAddresses.RootDsAddress)))
-		// eUICC Manufacturer Label
 		if eum := GetEUM(ChipInfo.EidValue); eum != nil {
 			manufacturer := fmt.Sprint(eum.Manufacturer, " ", CountryCodeToEmoji(eum.Country))
 			EUICCManufacturerLabel.SetText(TR.Trans("label.manufacturer") + " " + manufacturer)
 		} else {
 			EUICCManufacturerLabel.SetText(TR.Trans("label.manufacturer_unknown"))
 		}
-		// EUICCInfo2 entry
 		bytes, err := json.MarshalIndent(ChipInfo.EUICCInfo2, "", "  ")
 		if err != nil {
 			ShowLpacErrDialog(fmt.Errorf(TR.Trans("message.failed_to_decode_euiccinfo2")+"\n%s", err))
 		}
 		EuiccInfo2Entry.SetText(string(bytes))
-		// 计算剩余空间
 		freeSpace := float64(ChipInfo.EUICCInfo2.ExtCardResource.FreeNonVolatileMemory) / 1024
 		FreeSpaceLabel.SetText(fmt.Sprintf(TR.Trans("label.free_space")+" %.2f KiB", math.Round(freeSpace*100)/100))
 
@@ -114,28 +108,14 @@ func RefreshChipInfo() error {
 	return nil
 }
 
-func RefreshApduDriver() {
+// DiscoverDrivers queries available APDU drivers from lpac
+func DiscoverDrivers() error {
 	var err error
-	ApduDrivers, err = LpacDriverApduList()
+	AvailableDrivers, err = LpacDriverList()
 	if err != nil {
-		ShowLpacErrDialog(err)
+		return err
 	}
-	var options []string
-	for _, d := range ApduDrivers {
-		// exclude YubiKey and CanoKey
-		if strings.Contains(d.Name, "canokeys.org") || strings.Contains(d.Name, "YubiKey") {
-			continue
-		}
-		// Workaround: lpac shows an empty driver when no card reader inserted under macOS
-		if d.Name == "" {
-			continue
-		}
-		options = append(options, d.Name)
-	}
-	ApduDriverSelect.SetOptions(options)
-	ApduDriverSelect.ClearSelected()
-	ConfigInstance.DriverIFID = ""
-	ApduDriverSelect.Refresh()
+	return nil
 }
 
 func OpenLog() {
@@ -162,12 +142,8 @@ func OpenProgram(name string) error {
 }
 
 func Refresh() {
-	if ConfigInstance.ApduBackend == "pcsc" && ConfigInstance.DriverIFID == "" {
-		ShowSelectCardReaderDialog()
-		return
-	}
-	if ConfigInstance.ApduBackend == "mbim" && ConfigInstance.MbimDevice == "" {
-		ShowSelectMbimDeviceDialog()
+	if !isApduConfigured() {
+		showApduNotConfiguredDialog()
 		return
 	}
 	err := RefreshProfile()
@@ -210,7 +186,7 @@ func LockButtonListener() {
 	buttons := []*widget.Button{
 		RefreshButton, DownloadButton, SetNicknameButton, SwitchStateButton, DeleteProfileButton,
 		ProcessNotificationButton, ProcessAllNotificationButton, RemoveNotificationButton, BatchRemoveNotificationButton,
-		SetDefaultSmdpButton, ApduDriverRefreshButton,
+		SetDefaultSmdpButton, DeviceSelectRefresh,
 	}
 	checks := []*widget.Check{
 		ProfileMaskCheck, NotificationMaskCheck,
@@ -220,36 +196,51 @@ func LockButtonListener() {
 		fyne.Do(func() {
 			if lock {
 				for _, button := range buttons {
-					button.Disable()
+					if button != nil {
+						button.Disable()
+					}
 				}
 				for _, check := range checks {
-					check.Disable()
+					if check != nil {
+						check.Disable()
+					}
 				}
-				ApduDriverSelect.Disable()
+				if ApduBackendSelect != nil {
+					ApduBackendSelect.Disable()
+				}
+				if DeviceSelect != nil {
+					DeviceSelect.Disable()
+				}
+				if DeviceEntry != nil {
+					DeviceEntry.Disable()
+				}
+				if UimSlotEntry != nil {
+					UimSlotEntry.Disable()
+				}
 			} else {
 				for _, button := range buttons {
-					button.Enable()
+					if button != nil {
+						button.Enable()
+					}
 				}
 				for _, check := range checks {
-					check.Enable()
+					if check != nil {
+						check.Enable()
+					}
 				}
-				ApduDriverSelect.Enable()
+				if ApduBackendSelect != nil {
+					ApduBackendSelect.Enable()
+				}
+				if DeviceSelect != nil {
+					DeviceSelect.Enable()
+				}
+				if DeviceEntry != nil {
+					DeviceEntry.Enable()
+				}
+				if UimSlotEntry != nil {
+					UimSlotEntry.Enable()
+				}
 			}
 		})
-	}
-}
-
-func SetDriverIFID(name string) {
-	for _, d := range ApduDrivers {
-		if name == d.Name {
-			// 未选择过读卡器
-			if ConfigInstance.DriverIFID == "" {
-				ConfigInstance.DriverIFID = d.Env
-			} else {
-				// 选择过读卡器，要求刷新
-				ConfigInstance.DriverIFID = d.Env
-				RefreshNeeded = true
-			}
-		}
 	}
 }

--- a/control.go
+++ b/control.go
@@ -162,8 +162,12 @@ func OpenProgram(name string) error {
 }
 
 func Refresh() {
-	if ConfigInstance.DriverIFID == "" {
+	if ConfigInstance.ApduBackend == "pcsc" && ConfigInstance.DriverIFID == "" {
 		ShowSelectCardReaderDialog()
+		return
+	}
+	if ConfigInstance.ApduBackend == "mbim" && ConfigInstance.MbimDevice == "" {
+		ShowSelectMbimDeviceDialog()
 		return
 	}
 	err := RefreshProfile()

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -84,6 +84,9 @@ label:
   card_reader: "Card Reader:"
   apdu_backend: "Backend:"
   mbim_device: "MBIM Device:"
+  device: "Device:"
+  uim_slot: "Slot:"
+  no_config_needed: "(no configuration needed)"
 
 dialog:
   hint: Hint
@@ -135,6 +138,8 @@ message:
   select_item: Please select a item.
   select_card_reader: Please select a card reader.
   enter_mbim_device: Please enter an MBIM device path.
+  select_backend: Please select an APDU backend.
+  enter_device_path: Please enter a device path.
   refresh_required: Please refresh before proceeding.
   failed_to_decode_euiccinfo2: "chip Info: failed to decode EUICCInfo2"
   qr_code_format_error: failed to decode LPA Activation Code from QR Code

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -82,6 +82,8 @@ label:
   manufacturer_unknown: "Manufacturer: Unknown"
   free_space: "Free space:"
   card_reader: "Card Reader:"
+  apdu_backend: "Backend:"
+  mbim_device: "MBIM Device:"
 
 dialog:
   hint: Hint
@@ -132,6 +134,7 @@ message:
   lpac_error: Please check the log for details
   select_item: Please select a item.
   select_card_reader: Please select a card reader.
+  enter_mbim_device: Please enter an MBIM device path.
   refresh_required: Please refresh before proceeding.
   failed_to_decode_euiccinfo2: "chip Info: failed to decode EUICCInfo2"
   qr_code_format_error: failed to decode LPA Activation Code from QR Code

--- a/i18n/ja-JP.yaml
+++ b/i18n/ja-JP.yaml
@@ -84,6 +84,9 @@ label:
   card_reader: "カードリーダー:"
   apdu_backend: "バックエンド:"
   mbim_device: "MBIM デバイス:"
+  device: "デバイス:"
+  uim_slot: "スロット:"
+  no_config_needed: "(設定不要)"
 
 dialog:
   hint: ヒント
@@ -135,6 +138,8 @@ message:
   select_item: 項目を選択してください。
   select_card_reader: カードリーダーを選択してください。
   enter_mbim_device: MBIM デバイスパスを入力してください。
+  select_backend: APDU バックエンドを選択してください。
+  enter_device_path: デバイスパスを入力してください。
   refresh_required: 続行する前に更新してください。
   failed_to_decode_euiccinfo2: "チップ情報: EUICCInfo2 のデコードに失敗しました"
   qr_code_format_error: QR コードから LPA アクティベーションコードのデコードに失敗しました

--- a/i18n/ja-JP.yaml
+++ b/i18n/ja-JP.yaml
@@ -82,6 +82,8 @@ label:
   manufacturer_unknown: "製造: 不明"
   free_space: "空き容量:"
   card_reader: "カードリーダー:"
+  apdu_backend: "バックエンド:"
+  mbim_device: "MBIM デバイス:"
 
 dialog:
   hint: ヒント
@@ -132,6 +134,7 @@ message:
   lpac_error: 詳細はログを確認してください。
   select_item: 項目を選択してください。
   select_card_reader: カードリーダーを選択してください。
+  enter_mbim_device: MBIM デバイスパスを入力してください。
   refresh_required: 続行する前に更新してください。
   failed_to_decode_euiccinfo2: "チップ情報: EUICCInfo2 のデコードに失敗しました"
   qr_code_format_error: QR コードから LPA アクティベーションコードのデコードに失敗しました

--- a/i18n/zh-TW.yaml
+++ b/i18n/zh-TW.yaml
@@ -84,6 +84,9 @@ label:
   card_reader: "讀卡機:"
   apdu_backend: "後端:"
   mbim_device: "MBIM 裝置:"
+  device: "裝置:"
+  uim_slot: "卡槽:"
+  no_config_needed: "(無需配置)"
 
 dialog:
   hint: 提示
@@ -135,6 +138,8 @@ message:
   select_item: 請選擇一個項目。
   select_card_reader: 請選擇一個讀卡機。
   enter_mbim_device: 請輸入 MBIM 裝置路徑。
+  select_backend: 請選擇 APDU 後端。
+  enter_device_path: 請輸入裝置路徑。
   refresh_required: 請重新整理新再繼續。
   failed_to_decode_euiccinfo2: "晶片資訊: 無法解碼 EUICCInfo2 資訊"
   qr_code_format_error: 無法從 QR code 解碼 LPA 啟動碼

--- a/i18n/zh-TW.yaml
+++ b/i18n/zh-TW.yaml
@@ -82,6 +82,8 @@ label:
   manufacturer_unknown: "製造商: 未知"
   free_space: "可用空間:"
   card_reader: "讀卡機:"
+  apdu_backend: "後端:"
+  mbim_device: "MBIM 裝置:"
 
 dialog:
   hint: 提示
@@ -132,6 +134,7 @@ message:
   lpac_error: 請查看日誌了解詳情
   select_item: 請選擇一個項目。
   select_card_reader: 請選擇一個讀卡機。
+  enter_mbim_device: 請輸入 MBIM 裝置路徑。
   refresh_required: 請重新整理新再繼續。
   failed_to_decode_euiccinfo2: "晶片資訊: 無法解碼 EUICCInfo2 資訊"
   qr_code_format_error: 無法從 QR code 解碼 LPA 啟動碼

--- a/main.go
+++ b/main.go
@@ -60,9 +60,13 @@ func main() {
 		} else {
 			LpacVersionLabel.SetText(TR.Trans("label.lpac_version") + " " + version)
 		}
-		RefreshApduDriver()
-		if ApduDrivers != nil {
-			ApduDriverSelect.SetSelectedIndex(0)
+		// Discover available APDU drivers
+		if err2 := DiscoverDrivers(); err2 != nil {
+			d := dialog.NewError(fmt.Errorf("Failed to discover drivers: %v", err2), WMain)
+			d.Show()
+		} else {
+			PopulateBackendSelect()
+			updateDriverConfigUI()
 		}
 	}
 

--- a/widgets.go
+++ b/widgets.go
@@ -195,9 +195,16 @@ func InitWidgets() {
 	}
 	UimSlotEntry = &widget.Entry{
 		OnChanged: func(s string) {
-			onUimSlotChanged(s)
+			// Filter to numeric only and enforce minimum of 1
+			filtered := filterNumeric(s)
+			if filtered != s {
+				UimSlotEntry.SetText(filtered)
+				return
+			}
+			onUimSlotChanged(filtered)
 		},
 	}
+	UimSlotEntry.SetText("1")
 
 	// Initialize backend selector (will be populated after driver discovery)
 	ApduBackendSelect = widget.NewSelect([]string{}, func(s string) {
@@ -253,11 +260,34 @@ func onUimSlotChanged(slotStr string) {
 	if config == nil {
 		return
 	}
+	if slotStr == "" {
+		config.UimSlot = 1
+		SetCurrentDriverConfig(*config)
+		RefreshNeeded = true
+		return
+	}
 	if slot, err := strconv.Atoi(slotStr); err == nil && slot > 0 {
 		config.UimSlot = slot
 		SetCurrentDriverConfig(*config)
 		RefreshNeeded = true
 	}
+}
+
+// filterNumeric filters a string to only contain digits, returns "1" if empty or zero
+func filterNumeric(s string) string {
+	var result strings.Builder
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			result.WriteRune(r)
+		}
+	}
+	filtered := result.String()
+	// Remove leading zeros but keep at least one digit
+	filtered = strings.TrimLeft(filtered, "0")
+	if filtered == "" {
+		return "1"
+	}
+	return filtered
 }
 
 // updateDriverConfigUI updates the driver config UI based on selected backend
@@ -310,9 +340,11 @@ func updateDriverConfigUI() {
 		// Auto-refresh device list
 		go RefreshDeviceList()
 	} else if DriversWithDevicePath[driver] {
-		// Show device path entry
-		if config != nil {
+		// Show device path entry - only set text if explicitly configured
+		if config != nil && config.DevicePath != "" {
 			DeviceEntry.SetText(config.DevicePath)
+		} else {
+			DeviceEntry.SetText("")
 		}
 		DeviceEntry.SetPlaceHolder(GetDefaultDevicePath(driver))
 

--- a/widgets.go
+++ b/widgets.go
@@ -49,6 +49,11 @@ var CopyEuiccInfo2Button *widget.Button
 var ApduDriverSelect *widget.Select
 var ApduDriverRefreshButton *widget.Button
 
+var ApduBackendSelect *widget.Select
+var MbimDeviceEntry *widget.Entry
+var MbimDeviceContainer *fyne.Container
+var PcscContainer *fyne.Container
+
 var Tabs *container.AppTabs
 var ProfileTab *container.TabItem
 var NotificationTab *container.TabItem
@@ -184,11 +189,48 @@ func InitWidgets() {
 	ApduDriverRefreshButton = &widget.Button{OnTapped: func() { go RefreshApduDriver() },
 		Icon: theme.SearchReplaceIcon()}
 	LpacVersionLabel = &widget.Label{}
+
+	MbimDeviceEntry = &widget.Entry{
+		Text:        ConfigInstance.MbimDevice,
+		PlaceHolder: "/dev/cdc-wdm0",
+		OnChanged: func(s string) {
+			ConfigInstance.MbimDevice = s
+			if s != "" {
+				RefreshNeeded = true
+			}
+		},
+	}
+
+	ApduBackendSelect = widget.NewSelect([]string{"PC/SC", "MBIM"}, func(s string) {
+		switch s {
+		case "PC/SC":
+			ConfigInstance.ApduBackend = "pcsc"
+			ConfigInstance.DriverIFID = ""
+			if MbimDeviceContainer != nil {
+				MbimDeviceContainer.Hide()
+			}
+			if PcscContainer != nil {
+				PcscContainer.Show()
+			}
+			ApduDriverSelect.ClearSelected()
+		case "MBIM":
+			ConfigInstance.ApduBackend = "mbim"
+			ConfigInstance.DriverIFID = "mbim"
+			if PcscContainer != nil {
+				PcscContainer.Hide()
+			}
+			if MbimDeviceContainer != nil {
+				MbimDeviceContainer.Show()
+			}
+		}
+		RefreshNeeded = true
+	})
+	ApduBackendSelect.SetSelected("PC/SC")
 }
 
 func downloadButtonFunc() {
-	if ConfigInstance.DriverIFID == "" {
-		ShowSelectCardReaderDialog()
+	if !isApduConfigured() {
+		showApduNotConfiguredDialog()
 		return
 	}
 	if RefreshNeeded {
@@ -199,8 +241,8 @@ func downloadButtonFunc() {
 }
 
 func setNicknameButtonFunc() {
-	if ConfigInstance.DriverIFID == "" {
-		ShowSelectCardReaderDialog()
+	if !isApduConfigured() {
+		showApduNotConfiguredDialog()
 		return
 	}
 	if RefreshNeeded {
@@ -215,8 +257,8 @@ func setNicknameButtonFunc() {
 }
 
 func deleteProfileButtonFunc() {
-	if ConfigInstance.DriverIFID == "" {
-		ShowSelectCardReaderDialog()
+	if !isApduConfigured() {
+		showApduNotConfiguredDialog()
 		return
 	}
 	if RefreshNeeded {
@@ -332,8 +374,8 @@ func deleteProfileButtonFunc() {
 }
 
 func switchStateButtonFunc() {
-	if ConfigInstance.DriverIFID == "" {
-		ShowSelectCardReaderDialog()
+	if !isApduConfigured() {
+		showApduNotConfiguredDialog()
 		return
 	}
 	if RefreshNeeded {
@@ -390,8 +432,8 @@ func switchStateButtonFunc() {
 }
 
 func processNotificationButtonFunc() {
-	if ConfigInstance.DriverIFID == "" {
-		ShowSelectCardReaderDialog()
+	if !isApduConfigured() {
+		showApduNotConfiguredDialog()
 		return
 	}
 	if RefreshNeeded {
@@ -407,8 +449,8 @@ func processNotificationButtonFunc() {
 }
 
 func processAllNotificationButtonFunc() {
-	if ConfigInstance.DriverIFID == "" {
-		ShowSelectCardReaderDialog()
+	if !isApduConfigured() {
+		showApduNotConfiguredDialog()
 		return
 	}
 	if RefreshNeeded {
@@ -504,8 +546,8 @@ func processAllNotificationButtonFunc() {
 }
 
 func removeNotificationButtonFunc() {
-	if ConfigInstance.DriverIFID == "" {
-		ShowSelectCardReaderDialog()
+	if !isApduConfigured() {
+		showApduNotConfiguredDialog()
 		return
 	}
 	if RefreshNeeded {
@@ -541,8 +583,8 @@ func removeNotificationButtonFunc() {
 }
 
 func batchRemoveNotificationButtonFunc() {
-	if ConfigInstance.DriverIFID == "" {
-		ShowSelectCardReaderDialog()
+	if !isApduConfigured() {
+		showApduNotConfiguredDialog()
 		return
 	}
 	if RefreshNeeded {
@@ -655,8 +697,8 @@ func copyEuiccInfo2ButtonFunc() {
 }
 
 func setDefaultSmdpButtonFunc() {
-	if ConfigInstance.DriverIFID == "" {
-		ShowSelectCardReaderDialog()
+	if !isApduConfigured() {
+		showApduNotConfiguredDialog()
 		return
 	}
 	if RefreshNeeded {
@@ -1022,4 +1064,21 @@ func sliceContains[T comparable](slice []T, element T) bool {
 		}
 	}
 	return false
+}
+
+func isApduConfigured() bool {
+	if ConfigInstance.ApduBackend == "pcsc" {
+		return ConfigInstance.DriverIFID != ""
+	} else if ConfigInstance.ApduBackend == "mbim" {
+		return ConfigInstance.MbimDevice != ""
+	}
+	return false
+}
+
+func showApduNotConfiguredDialog() {
+	if ConfigInstance.ApduBackend == "pcsc" {
+		ShowSelectCardReaderDialog()
+	} else if ConfigInstance.ApduBackend == "mbim" {
+		ShowSelectMbimDeviceDialog()
+	}
 }

--- a/widgets.go
+++ b/widgets.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -46,13 +47,15 @@ var ViewCertInfoButton *widget.Button
 var EUICCManufacturerLabel *widget.Label
 var CopyEuiccInfo2Button *widget.Button
 
-var ApduDriverSelect *widget.Select
-var ApduDriverRefreshButton *widget.Button
-
+// Driver selection widgets
 var ApduBackendSelect *widget.Select
-var MbimDeviceEntry *widget.Entry
-var MbimDeviceContainer *fyne.Container
-var PcscContainer *fyne.Container
+var DriverConfigContainer *fyne.Container
+
+// Driver-specific config widgets (created dynamically)
+var DeviceSelect *widget.Select       // For drivers with enumeration (pcsc, at)
+var DeviceSelectRefresh *widget.Button
+var DeviceEntry *widget.Entry         // For drivers with device path (mbim, qmi, at_csim)
+var UimSlotEntry *widget.Entry        // For drivers with UIM slot (mbim, qmi)
 
 var Tabs *container.AppTabs
 var ProfileTab *container.TabItem
@@ -85,8 +88,8 @@ func (entry *ReadOnlyEntry) TappedSecondary(ev *fyne.PointEvent) {
 
 func NewReadOnlyEntry() *ReadOnlyEntry {
 	entry := &ReadOnlyEntry{}
-	entry.ExtendBaseWidget(entry) // 确保自定义的 widget 被正确地初始化
-	entry.MultiLine = true        // 支持多行文本
+	entry.ExtendBaseWidget(entry)
+	entry.MultiLine = true
 	entry.TextStyle = fyne.TextStyle{Monospace: true}
 	entry.Wrapping = fyne.TextWrapOff
 	return entry
@@ -145,22 +148,12 @@ func InitWidgets() {
 		Icon:     theme.ViewRefreshIcon()}
 
 	ProfileMaskCheck = widget.NewCheck(TR.Trans("label.profile_mask_check"), func(b bool) {
-		if b {
-			ProfileMaskNeeded = true
-			ProfileList.Refresh()
-		} else {
-			ProfileMaskNeeded = false
-			ProfileList.Refresh()
-		}
+		ProfileMaskNeeded = b
+		ProfileList.Refresh()
 	})
 	NotificationMaskCheck = widget.NewCheck(TR.Trans("label.notification_mask_check"), func(b bool) {
-		if b {
-			NotificationMaskNeeded = true
-			NotificationList.Refresh()
-		} else {
-			NotificationMaskNeeded = false
-			NotificationList.Refresh()
-		}
+		NotificationMaskNeeded = b
+		NotificationList.Refresh()
 	})
 
 	EidLabel = widget.NewLabel("")
@@ -185,47 +178,276 @@ func InitWidgets() {
 		OnTapped: func() { go copyEuiccInfo2ButtonFunc() },
 		Icon:     theme.ContentCopyIcon()}
 	CopyEuiccInfo2Button.Hide()
-	ApduDriverSelect = widget.NewSelect([]string{}, func(s string) { SetDriverIFID(s) })
-	ApduDriverRefreshButton = &widget.Button{OnTapped: func() { go RefreshApduDriver() },
-		Icon: theme.SearchReplaceIcon()}
 	LpacVersionLabel = &widget.Label{}
 
-	MbimDeviceEntry = &widget.Entry{
-		Text:        ConfigInstance.MbimDevice,
-		PlaceHolder: "/dev/cdc-wdm0",
+	// Initialize driver config widgets
+	DeviceSelect = widget.NewSelect([]string{}, func(s string) {
+		onDeviceSelected(s)
+	})
+	DeviceSelectRefresh = &widget.Button{
+		OnTapped: func() { go RefreshDeviceList() },
+		Icon:     theme.SearchReplaceIcon(),
+	}
+	DeviceEntry = &widget.Entry{
 		OnChanged: func(s string) {
-			ConfigInstance.MbimDevice = s
-			if s != "" {
-				RefreshNeeded = true
-			}
+			onDevicePathChanged(s)
+		},
+	}
+	UimSlotEntry = &widget.Entry{
+		OnChanged: func(s string) {
+			onUimSlotChanged(s)
 		},
 	}
 
-	ApduBackendSelect = widget.NewSelect([]string{"PC/SC", "MBIM"}, func(s string) {
-		switch s {
-		case "PC/SC":
-			ConfigInstance.ApduBackend = "pcsc"
-			ConfigInstance.DriverIFID = ""
-			if MbimDeviceContainer != nil {
-				MbimDeviceContainer.Hide()
-			}
-			if PcscContainer != nil {
-				PcscContainer.Show()
-			}
-			ApduDriverSelect.ClearSelected()
-		case "MBIM":
-			ConfigInstance.ApduBackend = "mbim"
-			ConfigInstance.DriverIFID = "mbim"
-			if PcscContainer != nil {
-				PcscContainer.Hide()
-			}
-			if MbimDeviceContainer != nil {
-				MbimDeviceContainer.Show()
+	// Initialize backend selector (will be populated after driver discovery)
+	ApduBackendSelect = widget.NewSelect([]string{}, func(s string) {
+		onBackendSelected(s)
+	})
+
+	// Container for driver-specific config (populated dynamically)
+	DriverConfigContainer = container.NewHBox()
+}
+
+// onBackendSelected handles backend driver selection
+func onBackendSelected(driverName string) {
+	ConfigInstance.ApduBackend = driverName
+	RefreshNeeded = true
+	updateDriverConfigUI()
+}
+
+// onDeviceSelected handles device selection from dropdown (pcsc, at)
+func onDeviceSelected(deviceName string) {
+	if deviceName == "" {
+		return
+	}
+	config := GetCurrentDriverConfig()
+	if config == nil {
+		return
+	}
+
+	// Find the env value for this device name
+	for _, d := range ApduDrivers {
+		if d.Name == deviceName {
+			config.DriverIFID = d.Env
+			SetCurrentDriverConfig(*config)
+			RefreshNeeded = true
+			return
+		}
+	}
+}
+
+// onDevicePathChanged handles device path entry changes
+func onDevicePathChanged(path string) {
+	config := GetCurrentDriverConfig()
+	if config == nil {
+		return
+	}
+	config.DevicePath = path
+	SetCurrentDriverConfig(*config)
+	RefreshNeeded = true
+}
+
+// onUimSlotChanged handles UIM slot entry changes
+func onUimSlotChanged(slotStr string) {
+	config := GetCurrentDriverConfig()
+	if config == nil {
+		return
+	}
+	if slot, err := strconv.Atoi(slotStr); err == nil && slot > 0 {
+		config.UimSlot = slot
+		SetCurrentDriverConfig(*config)
+		RefreshNeeded = true
+	}
+}
+
+// updateDriverConfigUI updates the driver config UI based on selected backend
+func updateDriverConfigUI() {
+	if DriverConfigContainer == nil {
+		return
+	}
+
+	driver := ConfigInstance.ApduBackend
+	config := GetCurrentDriverConfig()
+
+	// Clear current config UI
+	DriverConfigContainer.Objects = nil
+
+	// Skip unknown drivers
+	if !IsKnownDriver(driver) {
+		DriverConfigContainer.Refresh()
+		return
+	}
+
+	if DriversNoConfig[driver] {
+		// No config needed for gbinder, gbinder_hidl
+		DriverConfigContainer.Objects = []fyne.CanvasObject{
+			widget.NewLabel(TR.Trans("label.no_config_needed")),
+		}
+		DriverConfigContainer.Refresh()
+		return
+	}
+
+	if DriversWithEnumeration[driver] {
+		// Show device dropdown with refresh button
+		DeviceSelect.ClearSelected()
+		DeviceSelect.SetOptions([]string{})
+		if config != nil && config.DriverIFID != "" {
+			// Try to find and select the current device
+			for _, d := range ApduDrivers {
+				if d.Env == config.DriverIFID {
+					DeviceSelect.SetSelected(d.Name)
+					break
+				}
 			}
 		}
-		RefreshNeeded = true
+
+		DriverConfigContainer.Objects = []fyne.CanvasObject{
+			widget.NewLabel(TR.Trans("label.device")),
+			container.NewGridWrap(fyne.Size{Width: 280, Height: DeviceSelect.MinSize().Height}, DeviceSelect),
+			DeviceSelectRefresh,
+		}
+
+		// Auto-refresh device list
+		go RefreshDeviceList()
+	} else if DriversWithDevicePath[driver] {
+		// Show device path entry
+		if config != nil {
+			DeviceEntry.SetText(config.DevicePath)
+		}
+		DeviceEntry.SetPlaceHolder(GetDefaultDevicePath(driver))
+
+		objects := []fyne.CanvasObject{
+			widget.NewLabel(TR.Trans("label.device")),
+			container.NewGridWrap(fyne.Size{Width: 200, Height: DeviceEntry.MinSize().Height}, DeviceEntry),
+		}
+
+		// Add UIM slot for drivers that need it
+		if DriversWithUimSlot[driver] {
+			if config != nil && config.UimSlot > 0 {
+				UimSlotEntry.SetText(strconv.Itoa(config.UimSlot))
+			} else {
+				UimSlotEntry.SetText("1")
+			}
+			UimSlotEntry.SetPlaceHolder("1")
+			objects = append(objects,
+				widget.NewLabel(TR.Trans("label.uim_slot")),
+				container.NewGridWrap(fyne.Size{Width: 50, Height: UimSlotEntry.MinSize().Height}, UimSlotEntry),
+			)
+		}
+		DriverConfigContainer.Objects = objects
+	}
+
+	DriverConfigContainer.Refresh()
+}
+
+// PopulateBackendSelect populates the backend selector with available drivers
+func PopulateBackendSelect() {
+	var options []string
+	for _, driver := range AvailableDrivers {
+		// Skip unknown drivers
+		if !IsKnownDriver(driver) {
+			continue
+		}
+		options = append(options, driver)
+	}
+	ApduBackendSelect.SetOptions(options)
+
+	// Select first available driver if none selected
+	if ConfigInstance.ApduBackend == "" && len(options) > 0 {
+		// Prefer pcsc if available
+		for _, opt := range options {
+			if opt == "pcsc" {
+				ApduBackendSelect.SetSelected("pcsc")
+				return
+			}
+		}
+		ApduBackendSelect.SetSelected(options[0])
+	} else if ConfigInstance.ApduBackend != "" {
+		ApduBackendSelect.SetSelected(ConfigInstance.ApduBackend)
+	}
+}
+
+// RefreshDeviceList refreshes the device list for drivers with enumeration
+func RefreshDeviceList() {
+	driver := ConfigInstance.ApduBackend
+	if !DriversWithEnumeration[driver] {
+		return
+	}
+
+	var err error
+	ApduDrivers, err = LpacDriverApduListForDriver(driver)
+	if err != nil {
+		ShowLpacErrDialog(err)
+		return
+	}
+
+	var options []string
+	for _, d := range ApduDrivers {
+		// Exclude YubiKey and CanoKey
+		if strings.Contains(d.Name, "canokeys.org") || strings.Contains(d.Name, "YubiKey") {
+			continue
+		}
+		// Workaround: lpac shows an empty driver when no card reader inserted under macOS
+		if d.Name == "" {
+			continue
+		}
+		options = append(options, d.Name)
+	}
+
+	fyne.Do(func() {
+		DeviceSelect.SetOptions(options)
+		DeviceSelect.ClearSelected()
+
+		// Clear the driver IFID since list changed
+		config := GetCurrentDriverConfig()
+		if config != nil {
+			config.DriverIFID = ""
+			SetCurrentDriverConfig(*config)
+		}
+		DeviceSelect.Refresh()
 	})
-	ApduBackendSelect.SetSelected("PC/SC")
+}
+
+// isApduConfigured checks if the current driver is properly configured
+func isApduConfigured() bool {
+	driver := ConfigInstance.ApduBackend
+	if driver == "" {
+		return false
+	}
+
+	config := GetCurrentDriverConfig()
+	if config == nil {
+		return false
+	}
+
+	if DriversNoConfig[driver] {
+		return true
+	}
+
+	if DriversWithEnumeration[driver] {
+		return config.DriverIFID != ""
+	}
+
+	if DriversWithDevicePath[driver] {
+		return config.DevicePath != ""
+	}
+
+	return false
+}
+
+// showApduNotConfiguredDialog shows appropriate dialog based on driver type
+func showApduNotConfiguredDialog() {
+	driver := ConfigInstance.ApduBackend
+	if driver == "" {
+		ShowSelectBackendDialog()
+		return
+	}
+
+	if DriversWithEnumeration[driver] {
+		ShowSelectCardReaderDialog()
+	} else if DriversWithDevicePath[driver] {
+		ShowEnterDevicePathDialog()
+	}
 }
 
 func downloadButtonFunc() {
@@ -305,12 +527,9 @@ func deleteProfileButtonFunc() {
 							return
 						}
 						if ConfigInstance.AutoMode {
-							// 默认保留 delete 通知
 							if err2 := LpacNotificationProcess(deleteNotification.SeqNumber, false); err2 != nil {
 								dialog.ShowError(errors.New(TR.Trans("message.successfully_delete_profile_failed_send_notification")), WMain)
 							} else {
-								// Ask to remove delete notification
-								// fixme 和手动操作通知模式重构
 								var d *dialog.CustomDialog
 								notNowButton := &widget.Button{
 									Text: "Not Now",
@@ -399,10 +618,6 @@ func switchStateButtonFunc() {
 		notificationsOrigin := Notifications
 		Refresh()
 		switchNotifications := findNewNotifications(notificationsOrigin, Notifications)
-		// 考虑两种情况
-		// 所有 Profile 禁用的情况下，启用 Profile 产生一个 enable 通知
-		// 有一个 Profile 已启用，启用另外一个，产生一个 disable 和一个 enable 通知
-		// 禁用 Profile，产生一个 disable 通知
 		if switchNotifications == nil || len(switchNotifications) > 2 {
 			dialog.ShowError(errors.New(TR.Trans("message.notification_not_found")), WMain)
 		} else {
@@ -716,11 +931,7 @@ func viewCertInfoButtonFunc() {
 		KeyID   string
 	}
 	var ciWidgetEls []ciWidgetEl
-	// ChipInfo 中 signing 和 verification 同时存在则有效
 	for _, keyId := range ChipInfo.EUICCInfo2.EuiccCiPKIDListForSigning {
-		// if !slices.Contains(ChipInfo.EUICCInfo2.EuiccCiPKIDListForVerification, keyId) {
-		// 	continue
-		// }
 		if !sliceContains(ChipInfo.EUICCInfo2.EuiccCiPKIDListForVerification, keyId) {
 			continue
 		}
@@ -863,11 +1074,9 @@ func initNotificationList() *widget.List {
 		suffix, _ := publicsuffix.PublicSuffix(fqdn)
 		parts := strings.Split(fqdn, ".")
 		suffixParts := strings.Split(suffix, ".")
-		// 如果域名部分少于后缀部分，说明域名不合法或者是一个裸域名，直接返回掩码后的顶级域名
 		if len(parts) <= len(suffixParts) {
 			return strings.Repeat("x", len(parts[0])) + "." + suffix
 		}
-		// 掩盖除了后缀之外的所有部分
 		for x := 0; x < len(parts)-len(suffixParts); x++ {
 			parts[x] = strings.Repeat("x", len(parts[x]))
 		}
@@ -906,16 +1115,12 @@ func initNotificationList() *widget.List {
 				}
 				notificationAddress = maskFQDNExceptPublicSuffix(Notifications[i].NotificationAddress)
 			}
-			// ICCID
 			if iccid == "" {
 				iccid = TR.Trans("label.no_iccid")
 			}
 			iccidLabel.SetText(fmt.Sprint("(", iccid, ")"))
-			// Notification Address
 			notificationAddressLabel.SetText(notificationAddress)
-			// Seq number
 			seqLabel.SetText(fmt.Sprint(TR.Trans("label.info_seq")+" ", Notifications[i].SeqNumber))
-			// Operation
 			switch Notifications[i].ProfileManagementOperation {
 			case "enable":
 				operationLabel.SetText(TR.Trans("label.notification_operation_enable"))
@@ -926,7 +1131,6 @@ func initNotificationList() *widget.List {
 			case "delete":
 				operationLabel.SetText(TR.Trans("label.notification_operation_delete"))
 			}
-			// Provider
 			profile, err := findProfileByIccid(Notifications[i].Iccid)
 			if err != nil {
 				providerLabel.SetText(TR.Trans("label.deleted_profile"))
@@ -969,7 +1173,6 @@ func processNotificationManually(seq int) {
 			}
 		}
 		if notification == nil {
-			// 不应该出现
 			dialog.ShowError(errors.New(TR.Trans("message.notification_not_found")), WMain)
 			return
 		}
@@ -1064,21 +1267,4 @@ func sliceContains[T comparable](slice []T, element T) bool {
 		}
 	}
 	return false
-}
-
-func isApduConfigured() bool {
-	if ConfigInstance.ApduBackend == "pcsc" {
-		return ConfigInstance.DriverIFID != ""
-	} else if ConfigInstance.ApduBackend == "mbim" {
-		return ConfigInstance.MbimDevice != ""
-	}
-	return false
-}
-
-func showApduNotConfiguredDialog() {
-	if ConfigInstance.ApduBackend == "pcsc" {
-		ShowSelectCardReaderDialog()
-	} else if ConfigInstance.ApduBackend == "mbim" {
-		ShowSelectMbimDeviceDialog()
-	}
 }

--- a/window.go
+++ b/window.go
@@ -24,7 +24,7 @@ var spacer *canvas.Rectangle
 func InitMainWindow() fyne.Window {
 	w := App.NewWindow("EasyLPAC")
 	w.Resize(fyne.Size{
-		Width:  850,
+		Width:  950,
 		Height: 545,
 	})
 	w.SetMaster()
@@ -37,24 +37,6 @@ func InitMainWindow() fyne.Window {
 	spacer = canvas.NewRectangle(color.Transparent)
 	spacer.SetMinSize(fyne.NewSize(1, 1))
 
-	PcscContainer = container.NewHBox(
-		widget.NewLabel(TR.Trans("label.card_reader")),
-		container.NewGridWrap(fyne.Size{
-			Width:  280,
-			Height: ApduDriverSelect.MinSize().Height,
-		}, ApduDriverSelect),
-		ApduDriverRefreshButton,
-	)
-
-	MbimDeviceContainer = container.NewHBox(
-		widget.NewLabel(TR.Trans("label.mbim_device")),
-		container.NewGridWrap(fyne.Size{
-			Width:  280,
-			Height: MbimDeviceEntry.MinSize().Height,
-		}, MbimDeviceEntry),
-	)
-	MbimDeviceContainer.Hide()
-
 	topToolBar := container.NewBorder(
 		layout.NewSpacer(),
 		nil,
@@ -63,11 +45,10 @@ func InitMainWindow() fyne.Window {
 		container.NewHBox(
 			widget.NewLabel(TR.Trans("label.apdu_backend")),
 			container.NewGridWrap(fyne.Size{
-				Width:  80,
+				Width:  100,
 				Height: ApduBackendSelect.MinSize().Height,
 			}, ApduBackendSelect),
-			PcscContainer,
-			MbimDeviceContainer,
+			DriverConfigContainer,
 		),
 	)
 
@@ -78,7 +59,6 @@ func InitMainWindow() fyne.Window {
 			nil,
 			nil,
 			container.NewHBox(ProfileMaskCheck, DownloadButton,
-				// spacer, DiscoveryButton,
 				spacer, SetNicknameButton,
 				spacer, SwitchStateButton,
 				spacer, DeleteProfileButton),
@@ -143,7 +123,6 @@ func InitMainWindow() fyne.Window {
 		if val != nil {
 			aidEntryHint.SetText(val.Error())
 		} else {
-			// Use last known good value only
 			ConfigInstance.LpacAID = s
 			aidEntryHint.SetText(TR.Trans("label.aid_valid"))
 		}
@@ -279,7 +258,6 @@ func InitDownloadDialog() dialog.Dialog {
 			}()
 		},
 	}
-	// 回调函数需要操作这两个 Button，预先声明
 	var selectQRCodeButton *widget.Button
 	var pasteFromClipboardButton *widget.Button
 	disableButtons := func() {
@@ -367,7 +345,6 @@ func InitDownloadDialog() dialog.Dialog {
 				case clipboard.FmtText:
 					pullInfo, confirmCodeNeeded, err = DecodeLpaActivationCode(CompleteActivationCode(string(result)))
 				default:
-					// Unreachable, should not be here.
 					panic("unexpected clipboard format")
 				}
 				if err != nil {
@@ -469,9 +446,15 @@ func ShowSelectCardReaderDialog() {
 	})
 }
 
-func ShowSelectMbimDeviceDialog() {
+func ShowSelectBackendDialog() {
 	fyne.Do(func() {
-		dialog.ShowInformation(TR.Trans("dialog.info"), TR.Trans("message.enter_mbim_device"), WMain)
+		dialog.ShowInformation(TR.Trans("dialog.info"), TR.Trans("message.select_backend"), WMain)
+	})
+}
+
+func ShowEnterDevicePathDialog() {
+	fyne.Do(func() {
+		dialog.ShowInformation(TR.Trans("dialog.info"), TR.Trans("message.enter_device_path"), WMain)
 	})
 }
 

--- a/window.go
+++ b/window.go
@@ -37,20 +37,38 @@ func InitMainWindow() fyne.Window {
 	spacer = canvas.NewRectangle(color.Transparent)
 	spacer.SetMinSize(fyne.NewSize(1, 1))
 
+	PcscContainer = container.NewHBox(
+		widget.NewLabel(TR.Trans("label.card_reader")),
+		container.NewGridWrap(fyne.Size{
+			Width:  280,
+			Height: ApduDriverSelect.MinSize().Height,
+		}, ApduDriverSelect),
+		ApduDriverRefreshButton,
+	)
+
+	MbimDeviceContainer = container.NewHBox(
+		widget.NewLabel(TR.Trans("label.mbim_device")),
+		container.NewGridWrap(fyne.Size{
+			Width:  280,
+			Height: MbimDeviceEntry.MinSize().Height,
+		}, MbimDeviceEntry),
+	)
+	MbimDeviceContainer.Hide()
+
 	topToolBar := container.NewBorder(
 		layout.NewSpacer(),
 		nil,
 		container.New(layout.NewHBoxLayout(), OpenLogButton, spacer, RefreshButton, spacer),
 		FreeSpaceLabel,
-		container.NewBorder(
-			nil,
-			nil,
-			widget.NewLabel(TR.Trans("label.card_reader")),
-			nil,
-			container.NewHBox(container.NewGridWrap(fyne.Size{
-				Width:  280,
-				Height: ApduDriverSelect.MinSize().Height,
-			}, ApduDriverSelect), ApduDriverRefreshButton)),
+		container.NewHBox(
+			widget.NewLabel(TR.Trans("label.apdu_backend")),
+			container.NewGridWrap(fyne.Size{
+				Width:  80,
+				Height: ApduBackendSelect.MinSize().Height,
+			}, ApduBackendSelect),
+			PcscContainer,
+			MbimDeviceContainer,
+		),
 	)
 
 	profileTabContent := container.NewBorder(
@@ -448,6 +466,12 @@ func ShowSelectItemDialog() {
 func ShowSelectCardReaderDialog() {
 	fyne.Do(func() {
 		dialog.ShowInformation(TR.Trans("dialog.info"), TR.Trans("message.select_card_reader"), WMain)
+	})
+}
+
+func ShowSelectMbimDeviceDialog() {
+	fyne.Do(func() {
+		dialog.ShowInformation(TR.Trans("dialog.info"), TR.Trans("message.enter_mbim_device"), WMain)
 	})
 }
 


### PR DESCRIPTION
## Summary

This PR adds support for integrated modem eSIM management via MBIM and other non-PC/SC APDU backends, replacing the previous hardcoded PC/SC-only approach with a fully dynamic, driver-aware system.

## Changes

### MBIM backend support (`feat: add MBIM backend support for integrated SIM cards`)

- Add backend selector (PC/SC / MBIM) in the toolbar
- Add MBIM device path configuration field with `LPAC_APDU_MBIM_DEVICE` env var support
- Update lpac invocation to pass correct environment variables per backend
- Also search `PATH` for the lpac binary (improves Nix compatibility)
- Add i18n translations for new UI elements (en, ja-JP, zh-TW)

### Generalized APDU backend with dynamic driver discovery (`feat: generalize APDU backend support`)

Refactored from a two-backend toggle to a fully dynamic driver system:

- Query `lpac driver list` on startup to enumerate all available backends
- Dynamic UI that adapts to the selected driver's configuration needs:
  - `pcsc` — device dropdown (existing behavior)
  - `at`, `at_csim` — device path field
  - `mbim` — device path + UIM slot
  - `qmi`, `qmi_qrtr`, `uqmi` — device path + UIM slot
  - `gbinder`, `gbinder_hidl` — no configuration needed
  - `stdio` — hidden from UI
- Per-driver configuration storage with environment variable defaults
- Switched from deprecated `DRIVER_IFID` to `LPAC_APDU_PCSC_DRV_IFID`
- Widened default window to accommodate driver config UI

### Fixes and UX improvements (`fix: improve driver parsing, UI inputs, and error display`)

- Fix `lpac driver list` JSON parsing to correctly read nested payload format
- Fix `lpac driver apdu list` parsing for nested payload arrays
- Make UIM slot entry numeric-only with a minimum value of 1
- Show device path defaults as placeholder text only (not pre-filled unless env var is set)
- Include stderr output in error dialogs for easier debugging

## Testing

Tested end-to-end on a **Lenovo ThinkPad X1 Yoga Gen 8** with the integrated modem exposed at `/dev/wwan0mbim0`:

- Successfully read eUICC info and profile list via MBIM backend
- Successfully downloaded an eSIM profile from a **Ubigi** activation code onto a **9eSim.com** eSIM card
