### PR TITLE
fix: pcsc reader selection and AT device path routing

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -201,11 +201,14 @@ func buildDriverEnv() []string {
 	case "pcsc":
 		if config.DriverIFID != "" {
 			env = append(env, fmt.Sprintf("LPAC_APDU_PCSC_DRV_IFID=%s", config.DriverIFID))
+			// lpac 2.x has a bug: LPAC_APDU_PCSC_DRV_NAME is only checked when IFID is set
+			// but doesn't match, and calling strstr with a NULL name causes a segfault.
+			// Setting NAME alongside IFID prevents the null dereference on non-matching readers.
+			if config.DriverName != "" {
+				env = append(env, fmt.Sprintf("LPAC_APDU_PCSC_DRV_NAME=%s", config.DriverName))
+			}
 		}
 	case "at":
-		if config.DriverIFID != "" {
-			env = append(env, fmt.Sprintf("LPAC_APDU_PCSC_DRV_IFID=%s", config.DriverIFID))
-		}
 		devicePath := config.DevicePath
 		if devicePath == "" {
 			devicePath = GetDefaultDevicePath("at")

--- a/config.go
+++ b/config.go
@@ -19,7 +19,8 @@ const AID_XESIM = "A0000005591010FFFFFFFF8900000177"
 type DriverConfig struct {
 	DevicePath string // Device path (for at, mbim, qmi drivers)
 	UimSlot    int    // UIM slot number (for mbim, qmi drivers)
-	DriverIFID string // Driver interface ID (for pcsc, at drivers with enumeration)
+	DriverIFID string // Driver interface ID / index (for pcsc driver enumeration)
+	DriverName string // Human-readable reader name (for pcsc, to work around lpac name-filter bug)
 }
 
 type Config struct {

--- a/widgets.go
+++ b/widgets.go
@@ -235,7 +235,16 @@ func onDeviceSelected(deviceName string) {
 	// Find the env value for this device name
 	for _, d := range ApduDrivers {
 		if d.Name == deviceName {
-			config.DriverIFID = d.Env
+			switch ConfigInstance.ApduBackend {
+			case "pcsc":
+				// Env is a reader index; store it alongside the full name.
+				// Both are needed to work around the lpac 2.x name-filter bug.
+				config.DriverIFID = d.Env
+				config.DriverName = d.Name
+			default:
+				// For "at" and any future enumeration drivers, Env is a device path.
+				config.DevicePath = d.Env
+			}
 			SetCurrentDriverConfig(*config)
 			RefreshNeeded = true
 			return


### PR DESCRIPTION
This PR fixes the pcsc reader selection and AT device path

## Problem

lpac <= v2.3.0 has two bugs in <https://github.com/estkme-group/lpac/blob/v2.3.0/driver/apdu/pcsc.c#L116-L133>:

### Bug 1 - LPAC_APDU_PCSC_DRV_NAME is silently ignored

The v2.3.0 condition is:

```c
if (id != -1 && id != index) {   // only true when IFID *is* set but doesn't match
    if (strstr(reader, part_name) == NULL) { return 0; }
}
```

When `LPAC_APDU_PCSC_DRV_IFID` is not set, the name filter is never evaluated. Every reader is tried unconditionally. On systems with a Virtual PCD reader at index 0 (common on Linux with vpcd or NFC stacks), lpac connects to it first, gets `SCARD_E_NO_SMARTCARD` or a polkit denial, and aborts without ever reaching the actual eSIM reader.

### Bug 2 - segfault when IFID is set but NAME is not

In the same branch, <https://github.com/estkme-group/lpac/blob/v2.3.0/driver/apdu/pcsc.c#L122> is called without a `NULL` check on `part_name`. If `LPAC_APDU_PCSC_DRV_IFID` is set to select a reader but `LPAC_APDU_PCSC_DRV_NAME` is unset (the common case), readers before the selected index crash lpac instead of being skipped.

Both bugs were fixed upstream — the `NULL` check in <https://github.com/estkme-group/lpac/pull/403> and the full logic restructure in <https://github.com/estkme-group/lpac/pull/414> — but they are present in v2.3.0, which is the version currently shipped by several distributions (NixOS, etc.).

### Fix

pcsc driver - emit both `LPAC_APDU_PCSC_DRV_IFID` and `LPAC_APDU_PCSC_DRV_NAME` together when a reader is selected. With both set:

- Readers before the selected index hit the `id != -1 && id != index` branch → name filter is evaluated → doesn't match → skipped (no crash, no connect attempt)
- The selected reader hits `id == index` → bypasses the filter → connects

The reader name (`d.Name`) is now stored in `DriverConfig.DriverName` alongside the existing `DriverIFID`, and emitted as `LPAC_APDU_PCSC_DRV_NAME` in `buildDriverEnv`. This is backwards-compatible: with fixed lpac builds the IFID alone is sufficient; with buggy builds the NAME prevents the segfault on non-matching readers.

AT driver — `onDeviceSelected` was storing `d.Env` into `DriverIFID` for all enumeration-based drivers. For pcsc this is correct (`d.Env` is a reader index). For at, `d.Env` is the device path and belongs in `DevicePath` so that `buildDriverEnv` passes it as `LPAC_APDU_AT_DEVICE`. Previously, selecting a non-default AT device from the dropdown had no effect — `LPAC_APDU_AT_DEVICE` always fell back to `/dev/ttyUSB0`. The erroneous `LPAC_APDU_PCSC_DRV_IFID` emission for the at case is also removed.  
