### PR TITLE
feat: find lpac in $PATH on MacOS too

### DIFF
--- a/config.go
+++ b/config.go
@@ -140,7 +140,7 @@ func LoadConfig() error {
 	case "windows":
 		ConfigInstance.EXEName = "lpac.exe"
 		ConfigInstance.LogDir = filepath.Join(exeDir, "log")
-	case "linux":
+	case "linux", "darwin":
 		ConfigInstance.EXEName = "lpac"
 		ConfigInstance.LogDir = filepath.Join("/tmp", "EasyLPAC-log")
 		_, err = os.Stat(filepath.Join(ConfigInstance.LpacDir, ConfigInstance.EXEName))


### PR DESCRIPTION
nixpkgs adds a suitable lpac to $PATH, but EasyLPAC needs to look for it as well.